### PR TITLE
Disabling front for listing url rewrite

### DIFF
--- a/includes/class-listings.php
+++ b/includes/class-listings.php
@@ -125,7 +125,7 @@ class WP_Listings {
 				'menu_icon'		=> 'dashicons-admin-home',
 				'has_archive'	=> true,
 				'supports'		=> array( 'title', 'editor', 'author', 'comments', 'excerpt', 'thumbnail', 'revisions', 'genesis-seo', 'genesis-layouts', 'genesis-simple-sidebars', 'genesis-cpt-archives-settings'),
-				'rewrite'		=> array( 'slug' => $this->options['wp_listings_slug'], 'feeds' => true ),
+				'rewrite'		=> array( 'slug' => $this->options['wp_listings_slug'], 'feeds' => true, 'with_front' => false ),
 			)
 		);
 


### PR DESCRIPTION
Removing user created url structures before /listings that may exist, i.e. /blog/

Hey!

Using your plugin on a few sites and noticed that the url structure we were using /blog/postname was inputting the /blog before /listings as well, leaving a url of /blog/listings.  Set with_front to false in class-listings.php to fix this.
