### PR TITLE
Add support taxonomy override

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -13,7 +13,10 @@ function wp_listings_template_include( $template ) {
 	$post_type = 'listing';
 
     if ( wp_listings_is_taxonomy_of($post_type) ) {
-        if ( file_exists(get_stylesheet_directory() . '/archive-' . $post_type . '.php' ) ) {
+    	if ( file_exists(get_stylesheet_directory() . '/taxonomy-' . $post_type . '.php' ) ) {
+    	    return get_stylesheet_directory() . '/taxonomy-' . $post_type . '.php';
+    	}
+        elseif ( file_exists(get_stylesheet_directory() . '/archive-' . $post_type . '.php' ) ) {
             return get_stylesheet_directory() . '/archive-' . $post_type . '.php';
         } else {
             return dirname( __FILE__ ) . '/views/archive-' . $post_type . '.php';


### PR DESCRIPTION
With WordPress I should be able to create template files for each taxonomies and even each term of a taxonomy. However the plugin is preventing this. If a user creates any taxonomy template file it should override.

This fixes issue #29 