### PR TITLE
Add feature: auto-embed of video links

### DIFF
--- a/includes/views/single-listing.php
+++ b/includes/views/single-listing.php
@@ -196,7 +196,7 @@ function single_listing_post_content() {
 			<?php if (get_post_meta( $post->ID, '_listing_video', true) != '') { ?>
 			<div id="listing-video">
 				<div class="iframe-wrap">
-				<?php echo get_post_meta( $post->ID, '_listing_video', true); ?>
+				<?php echo wp_oembed_get( get_post_meta( $post->ID, '_listing_video', true) ); ?>
 				</div>
 			</div><!-- #listing-video -->
 			<?php } ?>


### PR DESCRIPTION
Uses WordPress wp_oembed_get function to auto-embed YouTube/Vimeo links
etc.