### PR TITLE
Implement auto-embedding of video URLs

### DIFF
--- a/includes/views/single-listing.php
+++ b/includes/views/single-listing.php
@@ -196,7 +196,7 @@ function single_listing_post_content() {
 			<?php if (get_post_meta( $post->ID, '_listing_video', true) != '') { ?>
 			<div id="listing-video">
 				<div class="iframe-wrap">
-				<?php echo get_post_meta( $post->ID, '_listing_video', true); ?>
+				<?php echo wp_oembed_get( get_post_meta( $post->ID, '_listing_video', true) ); ?>
 				</div>
 			</div><!-- #listing-video -->
 			<?php } ?>

--- a/includes/views/single-listing.php
+++ b/includes/views/single-listing.php
@@ -193,10 +193,14 @@ function single_listing_post_content() {
 			</div><!-- #listing-gallery -->
 			<?php } ?>
 
-			<?php if (get_post_meta( $post->ID, '_listing_video', true) != '') { ?>
+			<?php if (get_post_meta( $post->ID, '_listing_video', true) != '') {
+				$video_url = get_post_meta( $post->ID, '_listing_video', true);
+			?>
 			<div id="listing-video">
 				<div class="iframe-wrap">
-				<?php echo wp_oembed_get( get_post_meta( $post->ID, '_listing_video', true) ); ?>
+				<?php if (wp_oembed_get( $video_url )){
+					echo wp_oembed_get( $video_url );
+				} else { echo "<a href='$video_url'>$video_url</a>"; } ?>
 				</div>
 			</div><!-- #listing-video -->
 			<?php } ?>


### PR DESCRIPTION
Simplify code by introducing $video_url variable and updates to support
a false return value from wp_oembed_get.

Could probably still use better URL detection (such as if the admin
enters a URL without the ‘http://'
