### PR TITLE
Ensure widget styles apply everywhere

### DIFF
--- a/includes/class-featured-listings-widget.php
+++ b/includes/class-featured-listings-widget.php
@@ -8,7 +8,7 @@
 class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 
 	function __construct() {
-		$widget_ops  = array( 'classname' => 'wplistings-featured-listings clearfix', 'description' => __( 'Display grid-style featured listings', 'wp-listings' ), 'customize_selective_refresh' => true );
+		$widget_ops  = array( 'classname' => 'widget wplistings-featured-listings clearfix', 'description' => __( 'Display grid-style featured listings', 'wp-listings' ), 'customize_selective_refresh' => true );
 		$control_ops = array( 'width' => 300, 'height' => 350 );
 		parent::__construct( 'wplistings-featured-listings', __( 'IMPress Listings - Featured Listings', 'wp-listings' ), $widget_ops, $control_ops );
 	}

--- a/includes/class-listings-search-widget.php
+++ b/includes/class-listings-search-widget.php
@@ -8,7 +8,7 @@
 class WP_Listings_Search_Widget extends WP_Widget {
 
 	function __construct() {
-		$widget_ops = array( 'classname' => 'listings-search wp-listings-search', 'description' => __( 'Display listings search dropdown', 'wp-listings' ), 'customize_selective_refresh' => true );
+		$widget_ops = array( 'classname' => 'widget listings-search wp-listings-search', 'description' => __( 'Display listings search dropdown', 'wp-listings' ), 'customize_selective_refresh' => true );
 		$control_ops = array( 'width' => 300, 'height' => 350, 'id_base' => 'listings-search' );
 		parent::__construct( 'listings-search', __( 'IMPress Listings - Search', 'wp-listings' ), $widget_ops, $control_ops );
 	}


### PR DESCRIPTION
Some themes do not use the class 'widget' for their widgets by default. (ex: BeaverBuilder theme which uses fl-widget), so either the stylesheets need to be updated to not rely upon the 'widget' class, or this change needs to be implemented to ensure the widget class is used on all wp-listings widgets.